### PR TITLE
CAW-795: Adds spoken feedback 

### DIFF
--- a/js/stanford_gallery.js
+++ b/js/stanford_gallery.js
@@ -11,6 +11,7 @@ Drupal.behaviors.stanford_gallery = {
       rel : "group",
       scalePhotos : true,
       returnFocus : true,
+      trapFocus: true,
       maxWidth : "98%",
       maxHeight : "90%",
       title: function() {
@@ -56,4 +57,9 @@ StanfordGallery.caption = function(element) {
   return caption;
 };
 
-
+// Add spoken feedback to the next/prev buttons.
+jQuery(document).bind('cbox_complete', function() {
+  jQuery("#cboxTitle .caption")
+    .attr("role", "alert")
+    .attr("aria-live", "assertive");
+});


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds spoken feedback when navigating with colorbox arrows.

# Needed By (Date)
- February 16th, 2018

# Urgency
- Low

# Steps to Test

1. Clone cardinalatwork from anchorage and navigate to /connect/volunteer-opportunities/cardinal-work-cares/2017-cardinal-work-cares-giving-campaign/photos#main or deploy a new site with this feature enabled and create a page gallery node.
1.b Check out this branch and clear all caches
2. Enable voiceover or chrome vox
3. Tab navigate in to the gallery and press enter to expand the colorbox
4. Tab to the next and previous buttons. 
5. Press enter to navigate to the next image
6. Spoken feedback should read the caption aloud
7. Try again with the other arrow

# Affected Projects or Products
- Just this feature

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/CAW-795
- @linneawilliams 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)