### PR TITLE
CAW-795: Set the default alt text to caption

### DIFF
--- a/stanford_gallery.module
+++ b/stanford_gallery.module
@@ -55,11 +55,18 @@ function stanford_gallery_field_formatter_view($entity_type, $entity, $field, $i
 
   foreach ($items as $delta => $item) {
     if ($field_collection = field_collection_field_get_entity($item)) {
+
+      // Patch up empty alt text.
+      if (empty($field_collection->field_s_image_image[LANGUAGE_NONE][0]["alt"]) && isset($field_collection->field_s_image_caption[LANGUAGE_NONE][0]["safe_value"])) {
+        $field_collection->field_s_image_image[LANGUAGE_NONE][0]["alt"] = $field_collection->field_s_image_caption[LANGUAGE_NONE][0]["safe_value"];
+      }
+
       $element[$delta]['entity'] = $field_collection->view($view_mode);
       $element[$delta]['#theme_wrappers'] = array('field_collection_view');
       $element[$delta]['#attributes']['class'][] = 'field-collection-view';
       $element[$delta]['#attributes']['class'][] = 'clearfix';
       $element[$delta]['#attributes']['class'][] = drupal_clean_css_identifier('view-mode-' . $view_mode);
+
     }
   }
 
@@ -97,7 +104,3 @@ function stanford_gallery_field_formatter_view($entity_type, $entity, $field, $i
 
   return $element;
 }
-
-
-
-


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the default alt text of the image to the caption if it is available.

# Needed By (Date)
- Friday Feb 16, 2018

# Urgency
- Low

# Steps to Test

0. Check out this branch
1. Deploy a site with this module enabled and create a gallery node
2. Make sure the alt text is not set on an image or several images in the gallery
3. Enter captions for each of the images
4. View the rendered output and inspect for alt text

# Affected Projects or Products
- Just this module

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/CAW-795
- @linneawilliams 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)